### PR TITLE
Feature ImageData in SpeedyMediaSource  [improved]

### DIFF
--- a/src/core/speedy-media-source.js
+++ b/src/core/speedy-media-source.js
@@ -24,7 +24,7 @@ import { SpeedyPromise } from './speedy-promise';
 import { AbstractMethodError, IllegalArgumentError, IllegalOperationError, TimeoutError, ResourceNotLoadedError } from '../utils/errors';
 import { MediaType } from '../utils/types'
 
-/** @typedef {HTMLImageElement|HTMLVideoElement|HTMLCanvasElement|OffscreenCanvas|ImageBitmap} SpeedyMediaSourceNativeElement */
+/** @typedef {HTMLImageElement|HTMLVideoElement|HTMLCanvasElement|OffscreenCanvas|ImageBitmap|ImageData} SpeedyMediaSourceNativeElement */
 
 /** Internal token for protected constructors */
 const PRIVATE_TOKEN = Symbol();
@@ -68,6 +68,8 @@ export class SpeedyMediaSource
             return SpeedyOffscreenCanvasMediaSource.load(wrappedObject);
         else if(wrappedObject instanceof ImageBitmap)
             return SpeedyBitmapMediaSource.load(wrappedObject);
+        else if(wrappedObject instanceof ImageData)
+            return SpeedyImageDataMediaSource.load(wrappedObject);
         else
             throw new IllegalArgumentError(`Unsupported media type: ${wrappedObject}`);
     }
@@ -708,5 +710,95 @@ class SpeedyBitmapMediaSource extends SpeedyMediaSource
     static load(bitmap)
     {
         return new SpeedyBitmapMediaSource(PRIVATE_TOKEN)._load(bitmap);
+    }
+}
+
+/**
+ * ImageData media source:
+ * a wrapper around ImageData
+ */
+class SpeedyImageDataMediaSource extends SpeedyMediaSource {
+    /**
+     * @private Constructor
+     * @param {symbol} token
+     */
+    constructor(token) {
+        super(token);
+
+        /** @type {ImageData} image data */
+        this._data = null;
+    }
+
+    /**
+     * The underlying wrapped object
+     * @returns {ImageData}
+     */
+    get data() {
+        return this._data;
+    }
+
+    /**
+     * The type of the underlying media source
+     * @returns {MediaType}
+     */
+    get type() {
+        return MediaType.ImageData;
+    }
+
+    /**
+     * Media width, in pixels
+     * @returns {number}
+     */
+    get width() {
+        return this._data ? this._data.width : 0;
+    }
+
+    /**
+     * Media height, in pixels
+     * @returns {number}
+     */
+    get height() {
+        return this._data ? this._data.height : 0;
+    }
+
+    /**
+     * Clone this media source
+     * @returns {SpeedyPromise<SpeedyMediaSource>}
+     */
+    clone() {
+        if (this._data == null)
+            throw new IllegalOperationError(`Media not loaded`);
+
+        const imageDataCopy = new ImageData(
+            new Uint8ClampedArray(this._data.data),
+            this._data.width,
+            this._data.height
+        )
+
+        return SpeedyImageDataMediaSource.load(imageDataCopy);
+    }
+
+    /**
+     * Load the underlying media
+     * @param {ImageData} imageData
+     * @returns {SpeedyPromise<SpeedyMediaSource>}
+     */
+    _load(imageData) {
+        if (this.isLoaded())
+            this.release();
+
+        return new SpeedyPromise(resolve => {
+            this._data = imageData;
+            resolve(this);
+        });
+    }
+
+    /**
+     * Load the underlying media
+     * @param {ImageData} imageData
+     * @returns {SpeedyPromise<SpeedyMediaSource>}
+     */
+    static load(imageData) {
+        return new SpeedyImageDataMediaSource(PRIVATE_TOKEN)._load(imageData);
     }
 }

--- a/src/core/speedy-media.js
+++ b/src/core/speedy-media.js
@@ -112,7 +112,7 @@ export class SpeedyMedia
 
     /**
      * The type of the media attached to this SpeedyMedia object
-     * @returns {"image" | "video" | "canvas" | "bitmap" | "unknown"}
+     * @returns {"image" | "video" | "canvas" | "bitmap" | "data" | "unknown"}
      */
     get type()
     {
@@ -131,6 +131,9 @@ export class SpeedyMedia
 
             case MediaType.Bitmap:
                 return 'bitmap';
+            
+            case MediaType.ImageData:
+                return 'data';  
 
             default: // this shouldn't happen
                 return 'unknown';

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -28,6 +28,7 @@ export const MediaType = Object.freeze({
     Video: Symbol('Video'),
     Canvas: Symbol('Canvas'),
     Bitmap: Symbol('Bitmap'),
+    ImageData: Symbol('ImageData')
 });
 
 /**


### PR DESCRIPTION
This is the continue from PR #57.
It create a new **SpeedyImageDataMediaSource** class to handle ImageData, and a new MediaType `ImageData` for this reason.
It add only these files:

- src/core/speedy-media-source.js
- src/core/speedy-media.js
- src/utils/types.js

commits signed off with `git commit -s`